### PR TITLE
PinReset implementation

### DIFF
--- a/src/scripts/plugins/smartcards/eid/lux/EidLux.ts
+++ b/src/scripts/plugins/smartcards/eid/lux/EidLux.ts
@@ -9,7 +9,7 @@ import {AuthenticateOrSignData, GenericCertCard, GenericSecuredCertCard, Optiona
 import { CertificateResponse, CertificatesResponse, DataResponse, T1CResponse } from '../../../../core/service/CoreModel';
 import {
     AbstractEidLUX, AllCertsResponse, LuxAllDataResponse,
-    LuxidBiometricResponse, LuxidPictureResponse, LuxidSignatureImageResponse
+    LuxidBiometricResponse, LuxidPictureResponse, LuxidSignatureImageResponse, LuxPinResetData
 } from './EidLuxModel';
 import { PinEnforcer } from '../../../../util/PinEnforcer';
 import { CertParser } from '../../../../util/CertParser';
@@ -21,6 +21,7 @@ export class EidLux extends GenericCertCard implements AbstractEidLUX {
     static ADDRESS = '/address';
     static PHOTO = '/picture';
     static SIGNATURE_IMAGE = '/signature-image';
+    static PIN_RESET = 'reset-pin';
 
 
     // constructor
@@ -126,6 +127,10 @@ export class EidLux extends GenericCertCard implements AbstractEidLUX {
             undefined, EidLux.EncryptedPinHeader(this.pin), callback);
     }
 
+    public pinReset(body: LuxPinResetData, callback?: (error: RestException, data: T1CResponse) => (void | Promise<T1CResponse>)) {
+        return this.connection.post(this.baseUrl, this.containerSuffix(EidLux.PIN_RESET), body, undefined, undefined, callback);
+    }
+
     protected getCertificate(certUrl: string,
                              options: RequestOptions,
                              params?: QueryParams,
@@ -152,4 +157,6 @@ export class EidLux extends GenericCertCard implements AbstractEidLUX {
             }, err => { return ResponseHandler.error(err, options.callback); });
         });
     }
+
+
 }

--- a/src/scripts/plugins/smartcards/eid/lux/EidLuxModel.ts
+++ b/src/scripts/plugins/smartcards/eid/lux/EidLuxModel.ts
@@ -3,9 +3,9 @@
  * @since 2017
  */
 import {RestException} from '../../../../core/exceptions/CoreExceptions';
-import {CertCard, OptionalPin, SecuredCertCard} from '../../Card';
+import {CertCard, OptionalPin, ResetPinData, SecuredCertCard} from '../../Card';
 import {
-    CertificateResponse, CertificatesResponse, DataObjectResponse, T1CCertificate
+    CertificateResponse, CertificatesResponse, DataObjectResponse, T1CCertificate, T1CResponse
 } from '../../../../core/service/CoreModel';
 import {Options} from '../../../../util/RequestHandler';
 
@@ -33,6 +33,8 @@ export interface AbstractEidLUX extends CertCard {
                               callback?: (error: RestException, data: CertificateResponse) => void): Promise<CertificateResponse>;
 
     signatureImage(callback?: (error: RestException, data: LuxidSignatureImageResponse) => void): Promise<LuxidSignatureImageResponse>;
+
+    pinReset(body: LuxPinResetData, callback?: (error: RestException, data: T1CResponse) => void | Promise<T1CResponse>)
 }
 
 export class AllCertsResponse extends DataObjectResponse {
@@ -109,4 +111,8 @@ export class LuxidSignatureImageResponse extends DataObjectResponse {
     constructor(public data: LuxidSignatureImage, public success: boolean) {
         super(data, success);
     }
+}
+
+export class LuxPinResetData {
+    constructor(public os_dialog: boolean, public reset_only: boolean, public puk?: string, public pin?: string) {}
 }


### PR DESCRIPTION
- Interface
- implementation
- Response & Request objects

Do you want the Request object to be defined in the EidLuxModel.ts file or in the card.ts file?
had to put the optional parameters at the end for LuxPinResetData because of tslint errors.